### PR TITLE
Fix leaving conversations

### DIFF
--- a/src/codeu/chat/client/ClientConversation.java
+++ b/src/codeu/chat/client/ClientConversation.java
@@ -97,9 +97,8 @@ public final class ClientConversation {
     } else {
       LOG.info("New conversation: Title= \"%s\" UUID= %s", conv.title, conv.id);
 
-      currentSummary = conv.summary;
 
-      updateAllConversations(currentSummary != null);
+      updateAllConversations(conv.summary != null);
     }
   }
 

--- a/src/codeu/chat/client/commandline/Chat.java
+++ b/src/codeu/chat/client/commandline/Chat.java
@@ -325,7 +325,7 @@ public final class Chat {
     }
     if (newCurrent != previous) {
       clientContext.conversation.setCurrent(newCurrent);
-      broadCastReceiver.joinConversation(previous,newCurrent);
+      broadCastReceiver.joinConversation(newCurrent);
       clientContext.conversation.updateAllConversations(true);
     }
   }

--- a/src/codeu/chat/client/simplegui/ConversationPanel.java
+++ b/src/codeu/chat/client/simplegui/ConversationPanel.java
@@ -141,13 +141,12 @@ public final class ConversationPanel extends JPanel {
         if (objectList.getSelectedIndex() != -1) {
           final int index = objectList.getSelectedIndex();
           final String data = objectList.getSelectedValue();
-          final ConversationSummary previous = clientContext.conversation.getCurrent();
-          final ConversationSummary cs = ConversationPanel.this.lookupByTitle(data, index);
+          final ConversationSummary newCurrent = ConversationPanel.this.lookupByTitle(data, index);
 
-          clientContext.conversation.setCurrent(cs);
+          clientContext.conversation.setCurrent(newCurrent);
 
-          messagePanel.getReceiver().joinConversation(previous, cs);
-          messagePanel.update(cs);
+          messagePanel.getReceiver().joinConversation(newCurrent);
+          messagePanel.update(newCurrent);
         }
       }
     });

--- a/src/codeu/chat/server/BroadCastSystem.java
+++ b/src/codeu/chat/server/BroadCastSystem.java
@@ -125,6 +125,7 @@ public class BroadCastSystem {
           PrintWriter writer = new PrintWriter(out, true);
 
           Serializers.INTEGER.write(writer, NetworkCode.NEW_BROADCAST);
+          Uuid.SERIALIZER.write(writer, conversationId);
           Message.SERIALIZER.write(writer, message);
         }
 

--- a/src/codeu/chat/server/Server.java
+++ b/src/codeu/chat/server/Server.java
@@ -292,7 +292,6 @@ public final class Server {
 
     } else if (type == NetworkCode.JOIN_CONVERSATION_REQUEST) {
 
-      System.out.println("Conversation request received");
       ConversationSummary old = Serializers.nullable(ConversationSummary.SERIALIZER).read(in);
       ConversationSummary newCon = Serializers.nullable(ConversationSummary.SERIALIZER).read(in);
       broadCastSystem.switchConversation(connection, old, newCon);
@@ -300,7 +299,6 @@ public final class Server {
       synchronized (connection.out()) {
         Serializers.INTEGER.write(out, NetworkCode.JOIN_CONVERSATION_RESPONSE);
       }
-      System.out.println("Connection switched");
 
     } else if (type == NetworkCode.GET_USER_SCORE_REQUEST) {
 


### PR DESCRIPTION
Fixes an issue in which clients would not successfully leave a conversations broadcast list, if they had just added a new conversation before switching. This was caused because the clientConversation class would automatically change the 'current conversation' of the client, without notifying the server, whenever a client added a new conversation. 

This was removed, such that now clients will not automatically join conversations when they create them. Additionally, the broadcast receiver will now keep track of the users current conversation and only show messages that belong to that conversation. With this addition, broadcasted messages must now also send the conversation Uuid for which the message belongs, so that the client can check if this message broadcast is correct. 