### PR TITLE
fixed issue with sentiment score

### DIFF
--- a/src/codeu/chat/common/SentimentScore.java
+++ b/src/codeu/chat/common/SentimentScore.java
@@ -108,7 +108,6 @@ public class SentimentScore {
 
   private void updateScore(Sentiment sentiment) {
 
-    // todo: based on the given sentiment, update the sentiment score.
     /*
      * How will a specific score impact the users current score.
      * the sentiment has both a score and a magnitude. How will they both be used in the
@@ -122,8 +121,13 @@ public class SentimentScore {
     final double nextWeighting = Math.min(this.weighting + magnitude, 50);
 
     this.score = (this.score * this.weighting) +  (score * magnitude);
-    this.score /= nextWeighting;
+    this.score /= nextWeighting == 0 ? 1 : nextWeighting;
     this.weighting = nextWeighting;
+
+    if (Double.isNaN(this.score) || Double.isNaN(this.weighting)) {
+      this.score = 0;
+      this.weighting = 0;
+    }
 
   }
 


### PR DESCRIPTION
This fixes an issue with the Json serializer and the sentiment
analysis. If a users first message had a weighting of 0, score would be
divided by 0.

Additionally, Gson would throw an exception when attempting to
serialize NaN. For this reason, an additional check was added to ensure
that the score and weighting remain a number.