### PR TITLE
removed the environment variable

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -18,7 +18,6 @@ set -e
 
 mkdir -p bin
 
-export GOOGLE_APPLICATION_CREDENTIALS=./TestingNLAPI-03ba34a1872e.json
 
 javac -Xlint $(find * | grep "\\.java$") -d ./bin -sourcepath ./src -cp ./third_party/*:./bin
 javac -Xlint $(find * | grep "\\.java$") -d ./bin -sourcepath ./test -cp ./third_party/*:./bin

--- a/run_server.sh
+++ b/run_server.sh
@@ -39,7 +39,6 @@ if [[ "${TEAM_ID}" == "" || "${TEAM_SECRET}" == "" || "${PORT}" == "" || "${PERS
   exit 1
 fi
 
-export GOOGLE_APPLICATION_CREDENTIALS=./TestingNLAPI-03ba34a1872e.json
 
 if [ "${RELAY_ADDRESS}" == "" ] ; then
   java -cp ./third_party/*:./bin codeu.chat.ServerMain \


### PR DESCRIPTION
Removed the environment variable for the natural language API, from
make.sh and server.sh. This is no longer necessary since the readme
explains how to set up the environment.